### PR TITLE
[stable31] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,30 +36,15 @@
 				"npm": "^9.0.0 || ^10.0.0"
 			}
 		},
-		"node_modules/@ampproject/remapping": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-			"integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"peer": true,
-			"dependencies": {
-				"@jridgewell/gen-mapping": "^0.3.5",
-				"@jridgewell/trace-mapping": "^0.3.24"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-			"integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+			"integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.27.1",
+				"@babel/helper-validator-identifier": "^7.29.7",
 				"js-tokens": "^4.0.0",
 				"picocolors": "^1.1.1"
 			},
@@ -68,9 +53,9 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.0.tgz",
-			"integrity": "sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+			"integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -79,23 +64,23 @@
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.28.3",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.3.tgz",
-			"integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+			"integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@ampproject/remapping": "^2.2.0",
-				"@babel/code-frame": "^7.27.1",
-				"@babel/generator": "^7.28.3",
-				"@babel/helper-compilation-targets": "^7.27.2",
-				"@babel/helper-module-transforms": "^7.28.3",
-				"@babel/helpers": "^7.28.3",
-				"@babel/parser": "^7.28.3",
-				"@babel/template": "^7.27.2",
-				"@babel/traverse": "^7.28.3",
-				"@babel/types": "^7.28.2",
+				"@babel/code-frame": "^7.29.7",
+				"@babel/generator": "^7.29.7",
+				"@babel/helper-compilation-targets": "^7.29.7",
+				"@babel/helper-module-transforms": "^7.29.7",
+				"@babel/helpers": "^7.29.7",
+				"@babel/parser": "^7.29.7",
+				"@babel/template": "^7.29.7",
+				"@babel/traverse": "^7.29.7",
+				"@babel/types": "^7.29.7",
+				"@jridgewell/remapping": "^2.3.5",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -131,15 +116,15 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.28.3",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
-			"integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+			"integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/parser": "^7.28.3",
-				"@babel/types": "^7.28.2",
+				"@babel/parser": "^7.29.7",
+				"@babel/types": "^7.29.7",
 				"@jridgewell/gen-mapping": "^0.3.12",
 				"@jridgewell/trace-mapping": "^0.3.28",
 				"jsesc": "^3.0.2"
@@ -163,15 +148,15 @@
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.27.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-			"integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+			"integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/compat-data": "^7.27.2",
-				"@babel/helper-validator-option": "^7.27.1",
+				"@babel/compat-data": "^7.29.7",
+				"@babel/helper-validator-option": "^7.29.7",
 				"browserslist": "^4.24.0",
 				"lru-cache": "^5.1.1",
 				"semver": "^6.3.1"
@@ -241,9 +226,9 @@
 			}
 		},
 		"node_modules/@babel/helper-globals": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-			"integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+			"integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -267,31 +252,31 @@
 			}
 		},
 		"node_modules/@babel/helper-module-imports": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-			"integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+			"integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/traverse": "^7.27.1",
-				"@babel/types": "^7.27.1"
+				"@babel/traverse": "^7.29.7",
+				"@babel/types": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.28.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
-			"integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+			"integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/helper-module-imports": "^7.27.1",
-				"@babel/helper-validator-identifier": "^7.27.1",
-				"@babel/traverse": "^7.28.3"
+				"@babel/helper-module-imports": "^7.29.7",
+				"@babel/helper-validator-identifier": "^7.29.7",
+				"@babel/traverse": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -315,9 +300,9 @@
 			}
 		},
 		"node_modules/@babel/helper-plugin-utils": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
-			"integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+			"integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -379,27 +364,27 @@
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-			"integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+			"integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-			"integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+			"integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-option": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-			"integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+			"integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -424,27 +409,27 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.28.3",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.3.tgz",
-			"integrity": "sha512-PTNtvUQihsAsDHMOP5pfobP8C6CM4JWXmP8DrEIt46c3r2bf87Ua1zoqevsMo9g+tWDwgWrFP5EIxuBx5RudAw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+			"integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/template": "^7.27.2",
-				"@babel/types": "^7.28.2"
+				"@babel/template": "^7.29.7",
+				"@babel/types": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.28.3",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.3.tgz",
-			"integrity": "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+			"integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.28.2"
+				"@babel/types": "^7.29.7"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -1069,17 +1054,17 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-systemjs": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.27.1.tgz",
-			"integrity": "sha512-w5N1XzsRbc0PQStASMksmUeqECuzKuTJer7kFagK8AXgpCMkeDMO5S+aaFb7A51ZYDF7XI34qsTX+fkHiIm5yA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.7.tgz",
+			"integrity": "sha512-TM2ZcQLoG2/y4HODiStCo10DibYhWhGWAwVv+EQKmG/7GFl0N+AAmUiXOMKM+aiJ9XBJ9AHVZBvTzMnJ2sM3cQ==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/helper-module-transforms": "^7.27.1",
-				"@babel/helper-plugin-utils": "^7.27.1",
-				"@babel/helper-validator-identifier": "^7.27.1",
-				"@babel/traverse": "^7.27.1"
+				"@babel/helper-module-transforms": "^7.29.7",
+				"@babel/helper-plugin-utils": "^7.29.7",
+				"@babel/helper-validator-identifier": "^7.29.7",
+				"@babel/traverse": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1641,35 +1626,35 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.27.2",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-			"integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+			"integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/code-frame": "^7.27.1",
-				"@babel/parser": "^7.27.2",
-				"@babel/types": "^7.27.1"
+				"@babel/code-frame": "^7.29.7",
+				"@babel/parser": "^7.29.7",
+				"@babel/types": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.28.3",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.3.tgz",
-			"integrity": "sha512-7w4kZYHneL3A6NP2nxzHvT3HCZ7puDZZjFMqDpBPECub79sTtSO5CGXDkKrTQq8ksAwfD/XI2MRFX23njdDaIQ==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+			"integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/code-frame": "^7.27.1",
-				"@babel/generator": "^7.28.3",
-				"@babel/helper-globals": "^7.28.0",
-				"@babel/parser": "^7.28.3",
-				"@babel/template": "^7.27.2",
-				"@babel/types": "^7.28.2",
+				"@babel/code-frame": "^7.29.7",
+				"@babel/generator": "^7.29.7",
+				"@babel/helper-globals": "^7.29.7",
+				"@babel/parser": "^7.29.7",
+				"@babel/template": "^7.29.7",
+				"@babel/types": "^7.29.7",
 				"debug": "^4.3.1"
 			},
 			"engines": {
@@ -1677,13 +1662,13 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.28.2",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
-			"integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+			"integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-string-parser": "^7.27.1",
-				"@babel/helper-validator-identifier": "^7.27.1"
+				"@babel/helper-string-parser": "^7.29.7",
+				"@babel/helper-validator-identifier": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1915,9 +1900,9 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -1927,9 +1912,9 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"peer": true,
@@ -1952,38 +1937,38 @@
 			}
 		},
 		"node_modules/@file-type/xml": {
-			"version": "0.4.3",
-			"resolved": "https://registry.npmjs.org/@file-type/xml/-/xml-0.4.3.tgz",
-			"integrity": "sha512-pGRmkHf+NofNy/52r06HOTsEwdNnBsFEhN6U95s33P+ezuoxZEyBTV9lOB1/Zr0So6/9vDVfWZXLpgd0fy8cOQ==",
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/@file-type/xml/-/xml-0.4.4.tgz",
+			"integrity": "sha512-NhCyXoHlVZ8TqM476hyzwGJ24+D5IPSaZhmrPj7qXnEVb3q6jrFzA3mM9TBpknKSI9EuQeGTKRg2DXGUwvBBoQ==",
 			"license": "MIT",
 			"dependencies": {
 				"sax": "^1.4.1",
-				"strtok3": "^10.2.2"
+				"strtok3": "^10.3.4"
 			}
 		},
 		"node_modules/@floating-ui/core": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
-			"integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+			"version": "1.7.5",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+			"integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@floating-ui/utils": "^0.2.10"
+				"@floating-ui/utils": "^0.2.11"
 			}
 		},
 		"node_modules/@floating-ui/dom": {
-			"version": "1.7.4",
-			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
-			"integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+			"version": "1.7.6",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+			"integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@floating-ui/core": "^1.7.3",
-				"@floating-ui/utils": "^0.2.10"
+				"@floating-ui/core": "^1.7.5",
+				"@floating-ui/utils": "^0.2.11"
 			}
 		},
 		"node_modules/@floating-ui/utils": {
-			"version": "0.2.10",
-			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
-			"integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+			"version": "0.2.11",
+			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+			"integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
 			"license": "MIT"
 		},
 		"node_modules/@humanwhocodes/config-array": {
@@ -2004,9 +1989,9 @@
 			}
 		},
 		"node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -2016,9 +2001,9 @@
 			}
 		},
 		"node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"peer": true,
@@ -2092,6 +2077,18 @@
 			"peer": true,
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.0",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			}
+		},
+		"node_modules/@jridgewell/remapping": {
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+			"integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.5",
 				"@jridgewell/trace-mapping": "^0.3.24"
 			}
 		},
@@ -2344,31 +2341,30 @@
 			}
 		},
 		"node_modules/@nextcloud/auth": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-2.5.2.tgz",
-			"integrity": "sha512-1dr+Xhvg2QtsFC23KFXJSkU524EVgI/+WFBGTZ8tFa+9hmcZ3CqZIHjtXm3KxUvezwAY5023Ml0n2vpdYkpBXQ==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-2.6.0.tgz",
+			"integrity": "sha512-VkT87+9UqpPi7O36bVEE4/MxWF8d90VQcuMlvKltsZyLSLkEGrPXgowtD75Y54k60/8SR6mXbeqBwapi8dDUbA==",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
-				"@nextcloud/browser-storage": "^0.4.0",
-				"@nextcloud/event-bus": "^3.3.2"
+				"@nextcloud/browser-storage": "^0.5.0",
+				"@nextcloud/event-bus": "^3.3.3",
+				"@nextcloud/router": "^3.1.0"
 			},
 			"engines": {
 				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
 			}
 		},
 		"node_modules/@nextcloud/axios": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@nextcloud/axios/-/axios-2.5.1.tgz",
-			"integrity": "sha512-AA7BPF/rsOZWAiVxqlobGSdD67AEwjOnymZCKUIwEIBArKxYK7OQEqcILDjQwgj6G0e/Vg9Y8zTVsPZp+mlvwA==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/axios/-/axios-2.6.0.tgz",
+			"integrity": "sha512-ehcIgyora8DAJ+STG6iFI4e+ufPVFrIA6o0FgMKeKdfyaxRJ9UM7L+n7V+rc/qv8sDiWC/hWIKwFtLw2W5yE4Q==",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
-				"@nextcloud/auth": "^2.3.0",
-				"@nextcloud/router": "^3.0.1",
-				"axios": "^1.6.8"
+				"@nextcloud/auth": "^2.6.0",
+				"axios": "^1.15.0"
 			},
 			"engines": {
-				"node": "^20.0.0",
-				"npm": "^10.0.0"
+				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
 			}
 		},
 		"node_modules/@nextcloud/babel-config": {
@@ -2388,16 +2384,12 @@
 			}
 		},
 		"node_modules/@nextcloud/browser-storage": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/browser-storage/-/browser-storage-0.4.0.tgz",
-			"integrity": "sha512-D6XxznxCYmJ3oBCC3p0JB6GZJ2RZ9dgbB1UqtTePXrIvHUMBAeF/YkiGKYxLAVZCZb+NSNZXgAYHm/3LnIUbDg==",
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/browser-storage/-/browser-storage-0.5.0.tgz",
+			"integrity": "sha512-usYr4GlJQlK3hgZURvklqWb9ivi7sgsSuFqXrs7s4hl1LTS4enzPrnkQumm6nRsQruf0ITS+OBsK+oELEbvYPA==",
 			"license": "GPL-3.0-or-later",
-			"dependencies": {
-				"core-js": "3.37.0"
-			},
 			"engines": {
-				"node": "^20.0.0",
-				"npm": "^10.0.0"
+				"node": "^24 || ^22 || ^20"
 			}
 		},
 		"node_modules/@nextcloud/browserslist-config": {
@@ -2412,70 +2404,48 @@
 			}
 		},
 		"node_modules/@nextcloud/capabilities": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/capabilities/-/capabilities-1.2.0.tgz",
-			"integrity": "sha512-L1NQtOfHWzkfj0Ple1MEJt6HmOHWAi3y4qs+OnwSWexqJT0DtXTVPyRxi7ADyITwRxS5H9R/HMl6USAj4Nr1nQ==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@nextcloud/capabilities/-/capabilities-1.2.1.tgz",
+			"integrity": "sha512-snZ0/910zzwN6PDsIlx2Uvktr1S5x0ClhDUnfPlCj7ntNvECzuVHNY5wzby22LIkc+9ZjaDKtCwuCt2ye+9p/Q==",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
-				"@nextcloud/initial-state": "^2.1.0"
+				"@nextcloud/initial-state": "^3.0.0"
 			},
 			"engines": {
-				"node": "^20.0.0",
-				"npm": "^10.0.0"
-			}
-		},
-		"node_modules/@nextcloud/capabilities/node_modules/@nextcloud/initial-state": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/initial-state/-/initial-state-2.2.0.tgz",
-			"integrity": "sha512-cDW98L5KGGgpS8pzd+05304/p80cyu8U2xSDQGa+kGPTpUFmCbv2qnO5WrwwGTauyjYijCal2bmw82VddSH+Pg==",
-			"license": "GPL-3.0-or-later",
-			"engines": {
-				"node": "^20.0.0",
-				"npm": "^10.0.0"
+				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
 			}
 		},
 		"node_modules/@nextcloud/dialogs": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/@nextcloud/dialogs/-/dialogs-6.3.1.tgz",
-			"integrity": "sha512-lklTssGdphRZKoR07pYU88btqguEKcQjEpKYom342i1eiMPiejgmoPZEignWJvJhpaN9CT5FoGndCrqqS3BswA==",
+			"version": "6.4.2",
+			"resolved": "https://registry.npmjs.org/@nextcloud/dialogs/-/dialogs-6.4.2.tgz",
+			"integrity": "sha512-xj6fyUdb56StWt1DWeDHYnqK0Ck7EWQLUEyWtXHnneknoOV3x/Y0HPRL5L2PTJaDuVQB8TcVW53JjR38JG9W6Q==",
 			"license": "AGPL-3.0-or-later",
 			"dependencies": {
 				"@mdi/js": "^7.4.47",
-				"@nextcloud/auth": "^2.5.1",
-				"@nextcloud/axios": "^2.5.1",
-				"@nextcloud/browser-storage": "^0.4.0",
-				"@nextcloud/event-bus": "^3.3.2",
-				"@nextcloud/files": "^3.10.2",
-				"@nextcloud/initial-state": "^2.2.0",
-				"@nextcloud/l10n": "^3.3.0",
-				"@nextcloud/router": "^3.0.1",
-				"@nextcloud/sharing": "^0.2.4",
-				"@nextcloud/typings": "^1.9.1",
+				"@nextcloud/auth": "^2.5.3",
+				"@nextcloud/axios": "^2.5.2",
+				"@nextcloud/browser-storage": "^0.5.0",
+				"@nextcloud/event-bus": "^3.3.3",
+				"@nextcloud/files": "^3.12.2",
+				"@nextcloud/initial-state": "^3.0.0",
+				"@nextcloud/l10n": "^3.4.1",
+				"@nextcloud/paths": "^3.0.0",
+				"@nextcloud/router": "^3.1.0",
+				"@nextcloud/sharing": "^0.3.0",
 				"@types/toastify-js": "^1.12.4",
 				"@vueuse/core": "^11.3.0",
 				"cancelable-promise": "^4.3.1",
-				"p-queue": "^8.1.0",
+				"p-queue": "^9.0.1",
 				"toastify-js": "^1.12.0",
 				"vue-frag": "^1.4.3",
 				"webdav": "^5.8.0"
 			},
 			"engines": {
-				"node": "^20.0.0",
-				"npm": "^10.0.0"
+				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
 			},
 			"peerDependencies": {
-				"@nextcloud/vue": "^8.23.1",
+				"@nextcloud/vue": "^8.24.0",
 				"vue": "^2.7.16"
-			}
-		},
-		"node_modules/@nextcloud/dialogs/node_modules/@nextcloud/initial-state": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/initial-state/-/initial-state-2.2.0.tgz",
-			"integrity": "sha512-cDW98L5KGGgpS8pzd+05304/p80cyu8U2xSDQGa+kGPTpUFmCbv2qnO5WrwwGTauyjYijCal2bmw82VddSH+Pg==",
-			"license": "GPL-3.0-or-later",
-			"engines": {
-				"node": "^20.0.0",
-				"npm": "^10.0.0"
 			}
 		},
 		"node_modules/@nextcloud/eslint-config": {
@@ -2540,23 +2510,22 @@
 			}
 		},
 		"node_modules/@nextcloud/event-bus": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-3.3.2.tgz",
-			"integrity": "sha512-1Qfs6i7Tz2qd1A33NpBQOt810ydHIRjhyXMFwSEkYX2yUI80lAk/sWO8HIB2Fqp+iffhyviPPcQYoytMDRyDNw==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-3.3.3.tgz",
+			"integrity": "sha512-zIfvKmUGkXpVzRKoXrcO9hkoiKDm65fqNxy/XIbIxrQhZByPq3gDkjBpnu3V5Gs8JdYwa73R8DjzV9oH8HYhIg==",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
-				"@types/semver": "^7.5.8",
-				"semver": "^7.6.3"
+				"@types/semver": "^7.7.0",
+				"semver": "^7.7.2"
 			},
 			"engines": {
-				"node": "^20.0.0",
-				"npm": "^10.0.0"
+				"node": "^20 || ^22 || ^24"
 			}
 		},
 		"node_modules/@nextcloud/event-bus/node_modules/semver": {
-			"version": "7.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+			"version": "7.8.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -2566,20 +2535,20 @@
 			}
 		},
 		"node_modules/@nextcloud/files": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.12.0.tgz",
-			"integrity": "sha512-LVZklgooZzBj2jkbPRZO4jnnvW5+RvOn7wN5weyOZltF6i2wVMbg1Y/Czl2pi/UNMjUm5ENqc0j7FgxMBo8bwA==",
+			"version": "3.12.2",
+			"resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.12.2.tgz",
+			"integrity": "sha512-vBo8tf3Xh6efiF8CrEo3pKj9AtvAF6RdDGO1XKL65IxV8+UUd9Uxl2lUExHlzoDRRczCqfGfaWfRRaFhYqce5Q==",
 			"license": "AGPL-3.0-or-later",
 			"dependencies": {
-				"@nextcloud/auth": "^2.5.1",
-				"@nextcloud/capabilities": "^1.2.0",
-				"@nextcloud/l10n": "^3.3.0",
-				"@nextcloud/logger": "^3.0.2",
-				"@nextcloud/paths": "^2.2.1",
-				"@nextcloud/router": "^3.0.1",
-				"@nextcloud/sharing": "^0.2.4",
+				"@nextcloud/auth": "^2.5.3",
+				"@nextcloud/capabilities": "^1.2.1",
+				"@nextcloud/l10n": "^3.4.1",
+				"@nextcloud/logger": "^3.0.3",
+				"@nextcloud/paths": "^3.0.0",
+				"@nextcloud/router": "^3.1.0",
+				"@nextcloud/sharing": "^0.3.0",
 				"cancelable-promise": "^4.3.1",
-				"is-svg": "^6.0.0",
+				"is-svg": "^6.1.0",
 				"typescript-event-target": "^1.1.1",
 				"webdav": "^5.8.0"
 			},
@@ -2597,9 +2566,9 @@
 			}
 		},
 		"node_modules/@nextcloud/l10n": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/l10n/-/l10n-3.4.0.tgz",
-			"integrity": "sha512-K4UBSl0Ou6sXXLxyjuhktRf2FyTCjyvHxJyBLmS2z3YEYcRkpf8ib3XneRwEQIEpzBPQjul2/ZdFlt7umd8Gaw==",
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/@nextcloud/l10n/-/l10n-3.4.1.tgz",
+			"integrity": "sha512-aTFinTcKiK2gEXwLgutXekpZZ8/v/4QiC8C3QCLH5m0o+WtxsBC+fqV142ebC/rfDnzCLhY4ZtswSu8bFbZocg==",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@nextcloud/router": "^3.0.1",
@@ -2613,16 +2582,15 @@
 			}
 		},
 		"node_modules/@nextcloud/logger": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@nextcloud/logger/-/logger-3.0.2.tgz",
-			"integrity": "sha512-wByt0R0/6QC44RBpaJr1MWghjjOxk/pRbACHo/ZWWKht1qYbJRHB4GtEi+35KEIHY07ZpqxiDk6dIRuN7sXYWQ==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@nextcloud/logger/-/logger-3.0.3.tgz",
+			"integrity": "sha512-TcbVRL4/O5ffI1RXFmQAFD3gwwT15AAdr1770x+RNqVvfBdoGVyhzOwCIyA5Vfc3fA1iJXFa+rE6buJZSoqlcw==",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
-				"@nextcloud/auth": "^2.3.0"
+				"@nextcloud/auth": "^2.5.3"
 			},
 			"engines": {
-				"node": "^20.0.0",
-				"npm": "^10.0.0"
+				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
 			}
 		},
 		"node_modules/@nextcloud/moment": {
@@ -2640,69 +2608,61 @@
 			}
 		},
 		"node_modules/@nextcloud/password-confirmation": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/@nextcloud/password-confirmation/-/password-confirmation-5.3.1.tgz",
-			"integrity": "sha512-4+gcUBslO9QHI7UktsEB5qZv9FXojL+yMfIu9Rr2Z7V4ksTMxyqf2MaE4Utcs9BzcoS1oTRT5UxwdmfNkktraw==",
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/@nextcloud/password-confirmation/-/password-confirmation-5.3.2.tgz",
+			"integrity": "sha512-VtRBguZF8LvNn3I/kJ37upG8welNf7s1gnKwF3pQhC+F4n/Hgx6dp+LhM4fncHF7XH56i4LNZno+0IbvOkOQ8Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@nextcloud/auth": "^2.4.0",
-				"@nextcloud/axios": "^2.5.0",
-				"@nextcloud/dialogs": "^6.0.1",
-				"@nextcloud/l10n": "^3.1.0",
+				"@nextcloud/auth": "^2.5.3",
+				"@nextcloud/axios": "^2.5.2",
+				"@nextcloud/dialogs": "^6.4.1",
+				"@nextcloud/l10n": "^3.4.1",
 				"@nextcloud/router": "^3.0.1"
 			},
 			"engines": {
 				"node": "^20.0.0",
-				"npm": "^10.0.0"
+				"npm": "^10.5.1"
 			},
 			"peerDependencies": {
-				"@nextcloud/vue": "^8.0.0",
+				"@nextcloud/vue": "^8.23.0",
 				"vue": "^2.7.16"
 			}
 		},
 		"node_modules/@nextcloud/paths": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/@nextcloud/paths/-/paths-2.2.1.tgz",
-			"integrity": "sha512-M3ShLjrxR7B48eKThLMoqbxTqTKyQXcwf9TgeXQGbCIhiHoXU6as5j8l5qNv/uZlANokVdowpuWHBi3b2+YNNA==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/paths/-/paths-3.1.0.tgz",
+			"integrity": "sha512-vtFYA/kthaUDzu6KejTOL1OwnOy7/yynq5zdB/UBpYacAWjUX5Ddh4OMWx3rEavkBJ9/QGhrFryNJLjNfe8OQA==",
 			"license": "GPL-3.0-or-later",
 			"engines": {
-				"node": "^20.0.0",
-				"npm": "^10.0.0"
+				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
 			}
 		},
 		"node_modules/@nextcloud/router": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-3.0.1.tgz",
-			"integrity": "sha512-Ci/uD3x8OKHdxSqXL6gRJ+mGJOEXjeiHjj7hqsZqVTsT7kOrCjDf0/J8z5RyLlokKZ0IpSe+hGxgi3YB7Gpw3Q==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-3.1.0.tgz",
+			"integrity": "sha512-e4dkIaxRSwdZJlZFpn9x03QgBn/Sa2hN1hp/BA7+AbzykmSAlKuWfdmX8j/8ewrLpQwYmZR23IZO9XwpJXq2Uw==",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
-				"@nextcloud/typings": "^1.7.0"
-			},
-			"engines": {
-				"node": "^20.0.0",
-				"npm": "^10.0.0"
-			}
-		},
-		"node_modules/@nextcloud/sharing": {
-			"version": "0.2.5",
-			"resolved": "https://registry.npmjs.org/@nextcloud/sharing/-/sharing-0.2.5.tgz",
-			"integrity": "sha512-B3K5Dq9b5dexDA5n3AAuCF69Huwhrpw0J72fsVXV4KpPdImjhVPlExAv5o70AoXa+OqN4Rwn6gqJw+3ED892zg==",
-			"license": "GPL-3.0-or-later",
-			"dependencies": {
-				"@nextcloud/initial-state": "^2.2.0"
+				"@nextcloud/typings": "^1.10.0"
 			},
 			"engines": {
 				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
 			}
 		},
-		"node_modules/@nextcloud/sharing/node_modules/@nextcloud/initial-state": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/initial-state/-/initial-state-2.2.0.tgz",
-			"integrity": "sha512-cDW98L5KGGgpS8pzd+05304/p80cyu8U2xSDQGa+kGPTpUFmCbv2qnO5WrwwGTauyjYijCal2bmw82VddSH+Pg==",
+		"node_modules/@nextcloud/sharing": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/sharing/-/sharing-0.3.0.tgz",
+			"integrity": "sha512-kV7qeUZvd1fTKeFyH+W5Qq5rNOqG9rLATZM3U9MBxWXHJs3OxMqYQb8UQ3NYONzsX3zDGJmdQECIGHm1ei2sCA==",
 			"license": "GPL-3.0-or-later",
+			"dependencies": {
+				"@nextcloud/initial-state": "^3.0.0",
+				"is-svg": "^6.1.0"
+			},
 			"engines": {
-				"node": "^20.0.0",
-				"npm": "^10.0.0"
+				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
+			},
+			"optionalDependencies": {
+				"@nextcloud/files": "^3.12.0"
 			}
 		},
 		"node_modules/@nextcloud/stylelint-config": {
@@ -2724,64 +2684,51 @@
 				"stylelint-config-recommended-vue": "^1.5.0"
 			}
 		},
-		"node_modules/@nextcloud/timezones": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/timezones/-/timezones-0.2.0.tgz",
-			"integrity": "sha512-1mwQ+asTFOgv9rxPoAMEbDF8JfnenIa2EGNS+8MATCyi6WXxYh0Lhkaq1d3l2+xNbUPHgMnk4cRYsvIo319lkA==",
-			"license": "AGPL-3.0-or-later",
-			"dependencies": {
-				"ical.js": "^2.1.0"
-			},
-			"engines": {
-				"node": "^20 || ^22"
-			}
-		},
 		"node_modules/@nextcloud/typings": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/@nextcloud/typings/-/typings-1.9.1.tgz",
-			"integrity": "sha512-i0l/L5gKW8EACbXHVxXM6wn3sUhY2qmnL2OijppzU4dENC7/hqySMQDer7/+cJbNSNG7uHF/Z+9JmHtDfRfuGg==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/typings/-/typings-1.10.0.tgz",
+			"integrity": "sha512-SMC42rDjOH3SspPTLMZRv76ZliHpj2JJkF8pGLP8l1QrVTZxE47Qz5qeKmbj2VL+dRv2e/NgixlAFmzVnxkhqg==",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@types/jquery": "3.5.16"
 			},
 			"engines": {
-				"node": "^20.0.0",
-				"npm": "^10.0.0"
+				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
 			}
 		},
 		"node_modules/@nextcloud/vue": {
-			"version": "8.29.1",
-			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.29.1.tgz",
-			"integrity": "sha512-fJtKBmO1Al4SWZDsb2s+wmS1k+TkMQ+2Basx/M3VQsrczTpWqXOabsYdJR0ZoZgkL0suDPgK3p5OOEomWvLewA==",
+			"version": "8.39.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.39.0.tgz",
+			"integrity": "sha512-TJgrFeVr82CN8ng4y+IxMBb7mKlww7Fot22z33+Q0zKgWvi5EoQ0vYescA3Drl8cIRSGktUdFm3xO2gAqvnwoA==",
 			"license": "AGPL-3.0-or-later",
 			"dependencies": {
-				"@floating-ui/dom": "^1.1.0",
+				"@floating-ui/dom": "^1.7.6",
 				"@linusborg/vue-simple-portal": "^0.1.5",
-				"@nextcloud/auth": "^2.4.0",
-				"@nextcloud/axios": "^2.5.0",
-				"@nextcloud/browser-storage": "^0.4.0",
-				"@nextcloud/capabilities": "^1.2.0",
-				"@nextcloud/event-bus": "^3.3.2",
+				"@nextcloud/auth": "^2.6.0",
+				"@nextcloud/axios": "^2.5.2",
+				"@nextcloud/browser-storage": "^0.5.0",
+				"@nextcloud/capabilities": "^1.2.1",
+				"@nextcloud/event-bus": "^3.3.3",
 				"@nextcloud/initial-state": "^2.2.0",
-				"@nextcloud/l10n": "^3.4.0",
-				"@nextcloud/logger": "^3.0.2",
-				"@nextcloud/router": "^3.0.1",
-				"@nextcloud/sharing": "^0.2.3",
-				"@nextcloud/timezones": "^0.2.0",
-				"@nextcloud/vue-select": "^3.25.1",
+				"@nextcloud/l10n": "^3.4.1",
+				"@nextcloud/logger": "^3.0.3",
+				"@nextcloud/router": "^3.1.0",
+				"@nextcloud/sharing": "^0.4.0",
+				"@nextcloud/vue-select": "^3.26.0",
 				"@vueuse/components": "^11.0.0",
 				"@vueuse/core": "^11.0.0",
 				"blurhash": "^2.0.5",
 				"clone": "^2.1.2",
 				"debounce": "^2.2.0",
-				"dompurify": "^3.2.4",
-				"emoji-mart-vue-fast": "^15.0.4",
+				"dompurify": "^3.4.2",
+				"emoji-mart-vue-fast": "^15.0.5",
 				"escape-html": "^1.0.3",
 				"floating-vue": "^1.0.0-beta.19",
-				"focus-trap": "^7.4.3",
-				"linkify-string": "^4.0.0",
+				"focus-trap": "^7.8.0",
+				"linkify-string": "^4.3.2",
 				"md5": "^2.3.0",
-				"p-queue": "^8.1.0",
+				"mdast-util-to-string": "^4.0.0",
+				"p-queue": "^8.1.1",
 				"rehype-external-links": "^3.0.0",
 				"rehype-highlight": "^7.0.2",
 				"rehype-react": "^7.1.2",
@@ -2792,11 +2739,11 @@
 				"splitpanes": "^2.4.1",
 				"string-length": "^5.0.1",
 				"striptags": "^3.2.0",
-				"tabbable": "^6.2.0",
+				"tabbable": "^6.4.0",
 				"tributejs": "^5.1.3",
 				"unified": "^11.0.1",
 				"unist-builder": "^4.0.0",
-				"unist-util-visit": "^5.0.0",
+				"unist-util-visit-parents": "^6.0.2",
 				"vue": "^2.7.16",
 				"vue-color": "^2.8.1",
 				"vue-frag": "^1.4.3",
@@ -2808,12 +2755,12 @@
 			}
 		},
 		"node_modules/@nextcloud/vue-select": {
-			"version": "3.25.1",
-			"resolved": "https://registry.npmjs.org/@nextcloud/vue-select/-/vue-select-3.25.1.tgz",
-			"integrity": "sha512-jqCi4G+Q0H6+Hm8wSN3vRX2+eXG2jXR2bwBX/sErVEsH5UaxT4Nb7KqgdeIjVfeF7ccIdRqpmIb4Pkf0lao67w==",
+			"version": "3.26.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue-select/-/vue-select-3.26.0.tgz",
+			"integrity": "sha512-UvJExrxzx5pP3lv7j6zrv2yj6B1dXph7sh3lLNPnbJPjPoH/yg58mHNFBcPJrRYMbpy2t3hlC6F7s33KCTr9FA==",
 			"license": "MIT",
 			"engines": {
-				"node": "^20.0.0"
+				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
 			},
 			"peerDependencies": {
 				"vue": "2.x"
@@ -2829,10 +2776,63 @@
 				"npm": "^10.0.0"
 			}
 		},
+		"node_modules/@nextcloud/vue/node_modules/@nextcloud/sharing": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/sharing/-/sharing-0.4.0.tgz",
+			"integrity": "sha512-1hUNyc7uJdBpnimOnEshJjEtAPAjzDYVl6qmWqF5ZxoN9wOvbExw0QjX3xFIbHbX2dmvbRNLBj0RzLzipmZyeg==",
+			"license": "GPL-3.0-or-later",
+			"dependencies": {
+				"@nextcloud/initial-state": "^3.0.0",
+				"is-svg": "^6.1.0"
+			},
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
+			},
+			"optionalDependencies": {
+				"@nextcloud/files": "^3.12.2 || ^4.0.0"
+			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/@nextcloud/sharing/node_modules/@nextcloud/initial-state": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/initial-state/-/initial-state-3.0.0.tgz",
+			"integrity": "sha512-cV+HBdkQJGm8FxkBI5rFT/FbMNWNBvpbj6OPrg4Ae4YOOsQ15CL8InPOAw1t4XkOkQK2NEdUGQLVUz/19wXbdQ==",
+			"license": "GPL-3.0-or-later",
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
+			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/p-queue": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.1.1.tgz",
+			"integrity": "sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ==",
+			"license": "MIT",
+			"dependencies": {
+				"eventemitter3": "^5.0.1",
+				"p-timeout": "^6.1.2"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/p-timeout": {
+			"version": "6.1.4",
+			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
+			"integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/@nextcloud/webpack-vue-config": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/webpack-vue-config/-/webpack-vue-config-6.3.0.tgz",
-			"integrity": "sha512-Reciadvarap6j3d0arMH34zNiXx6d7B5QXDiosV6ZwDu63mR1lSm4ZUdLr6lv4gfmrADmQ5iP7PQMr99MBeTvw==",
+			"version": "6.3.2",
+			"resolved": "https://registry.npmjs.org/@nextcloud/webpack-vue-config/-/webpack-vue-config-6.3.2.tgz",
+			"integrity": "sha512-3ihWEW6kflGggVXNqL1gNrIx88GibJMIb1sC5CHjjZ/+2kkdOQ2HizoYKyMqPfcqji9UtwgdT+RlFVC4SViNJg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "AGPL-3.0-or-later",
@@ -2866,6 +2866,32 @@
 			"dependencies": {
 				"eslint-scope": "5.1.1"
 			}
+		},
+		"node_modules/@noble/hashes": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+			"integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 16"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/@nodable/entities": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+			"integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodable"
+				}
+			],
+			"license": "MIT"
 		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -3240,6 +3266,187 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/@peculiar/asn1-cms": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.8.0.tgz",
+			"integrity": "sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@peculiar/asn1-schema": "^2.8.0",
+				"@peculiar/asn1-x509": "^2.8.0",
+				"@peculiar/asn1-x509-attr": "^2.8.0",
+				"asn1js": "^3.0.10",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/asn1-csr": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.8.0.tgz",
+			"integrity": "sha512-akbF8+uvleHs8sejNPQxwmVFuInAg6FMNHOwMILXfP518YfFJwdR3jr6oNUPOaEJfuEhn/vkNOCIT6ASUd4mbg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@peculiar/asn1-schema": "^2.8.0",
+				"@peculiar/asn1-x509": "^2.8.0",
+				"asn1js": "^3.0.10",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/asn1-ecc": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.8.0.tgz",
+			"integrity": "sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@peculiar/asn1-schema": "^2.8.0",
+				"@peculiar/asn1-x509": "^2.8.0",
+				"asn1js": "^3.0.10",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/asn1-pfx": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.8.0.tgz",
+			"integrity": "sha512-5yof1ytoB++RQtaFbqSUJ8pxDJtZT6vbVqZ8XoJ61ph7UjNVvfFwAilnCodqkNsAodpy13gDhoxZXw00pghnyg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@peculiar/asn1-cms": "^2.8.0",
+				"@peculiar/asn1-pkcs8": "^2.8.0",
+				"@peculiar/asn1-rsa": "^2.8.0",
+				"@peculiar/asn1-schema": "^2.8.0",
+				"asn1js": "^3.0.10",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/asn1-pkcs8": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.8.0.tgz",
+			"integrity": "sha512-qAKXtLpBEw9LqhKpjw3ajZSXlBur+ipW+y2ivVBQAG6F6qRx94yO+1ZR4mvw+YaCfKSaOzLeYEzsPaBp4SJELA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@peculiar/asn1-schema": "^2.8.0",
+				"@peculiar/asn1-x509": "^2.8.0",
+				"asn1js": "^3.0.10",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/asn1-pkcs9": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.8.0.tgz",
+			"integrity": "sha512-b5nDWCnkV60+cQ141D6sVVwK9nz64R5n3zSVnklGd+ECdkW2Ol3U1a6yYFlalpSOaD557yuJB64A+q42jG7lUQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@peculiar/asn1-cms": "^2.8.0",
+				"@peculiar/asn1-pfx": "^2.8.0",
+				"@peculiar/asn1-pkcs8": "^2.8.0",
+				"@peculiar/asn1-schema": "^2.8.0",
+				"@peculiar/asn1-x509": "^2.8.0",
+				"@peculiar/asn1-x509-attr": "^2.8.0",
+				"asn1js": "^3.0.10",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/asn1-rsa": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.8.0.tgz",
+			"integrity": "sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@peculiar/asn1-schema": "^2.8.0",
+				"@peculiar/asn1-x509": "^2.8.0",
+				"asn1js": "^3.0.10",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/asn1-schema": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
+			"integrity": "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@peculiar/utils": "^2.0.2",
+				"asn1js": "^3.0.10",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/asn1-x509": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.8.0.tgz",
+			"integrity": "sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@peculiar/asn1-schema": "^2.8.0",
+				"@peculiar/utils": "^2.0.2",
+				"asn1js": "^3.0.10",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/asn1-x509-attr": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.8.0.tgz",
+			"integrity": "sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@peculiar/asn1-schema": "^2.8.0",
+				"@peculiar/asn1-x509": "^2.8.0",
+				"asn1js": "^3.0.10",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/utils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+			"integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/x509": {
+			"version": "1.14.3",
+			"resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.3.tgz",
+			"integrity": "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@peculiar/asn1-cms": "^2.6.0",
+				"@peculiar/asn1-csr": "^2.6.0",
+				"@peculiar/asn1-ecc": "^2.6.0",
+				"@peculiar/asn1-pkcs9": "^2.6.0",
+				"@peculiar/asn1-rsa": "^2.6.0",
+				"@peculiar/asn1-schema": "^2.6.0",
+				"@peculiar/asn1-x509": "^2.6.0",
+				"pvtsutils": "^1.3.6",
+				"reflect-metadata": "^0.2.2",
+				"tslib": "^2.8.1",
+				"tsyringe": "^4.10.0"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
 		"node_modules/@rtsao/scc": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -3338,21 +3545,11 @@
 			"version": "8.56.12",
 			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.12.tgz",
 			"integrity": "sha512-03ruubjWyOHlmljCVoxSuNDdmfZDzsrrz0P2LeJsOXr+ZwFQ+0yQIwNCwt/GYhV7Z31fgtXJTAEs+FYlEL851g==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "*",
 				"@types/json-schema": "*"
-			}
-		},
-		"node_modules/@types/eslint-scope": {
-			"version": "3.7.7",
-			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
-			"integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@types/eslint": "*",
-				"@types/estree": "*"
 			}
 		},
 		"node_modules/@types/estree": {
@@ -3362,9 +3559,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/express": {
-			"version": "4.17.23",
-			"resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.23.tgz",
-			"integrity": "sha512-Crp6WY9aTYP3qPi2wGDo9iUe/rceX01UMhnF1jmwDcKCFM6cx7YhGP/Mpr3y9AASpfHixIG0E6azCcL5OcDHsQ==",
+			"version": "4.17.25",
+			"resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+			"integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -3372,7 +3569,7 @@
 				"@types/body-parser": "*",
 				"@types/express-serve-static-core": "^4.17.33",
 				"@types/qs": "*",
-				"@types/serve-static": "*"
+				"@types/serve-static": "^1"
 			}
 		},
 		"node_modules/@types/express-serve-static-core": {
@@ -3499,17 +3696,6 @@
 				"undici-types": "~7.10.0"
 			}
 		},
-		"node_modules/@types/node-forge": {
-			"version": "1.3.14",
-			"resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.14.tgz",
-			"integrity": "sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
 		"node_modules/@types/qs": {
 			"version": "6.14.0",
 			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
@@ -3545,9 +3731,9 @@
 			"peer": true
 		},
 		"node_modules/@types/semver": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.0.tgz",
-			"integrity": "sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==",
+			"version": "7.7.1",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+			"integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
 			"license": "MIT"
 		},
 		"node_modules/@types/send": {
@@ -4685,9 +4871,9 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.15.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+			"version": "8.17.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+			"integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
 			"license": "MIT",
 			"peer": true,
 			"bin": {
@@ -4721,10 +4907,22 @@
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
 		},
+		"node_modules/agent-base": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6.0.0"
+			}
+		},
 		"node_modules/ajv": {
-			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -4757,9 +4955,9 @@
 			}
 		},
 		"node_modules/ajv-formats/node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
@@ -4833,6 +5031,18 @@
 			"engines": {
 				"node": ">= 8"
 			}
+		},
+		"node_modules/anynum": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+			"integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT"
 		},
 		"node_modules/are-docs-informative": {
 			"version": "0.0.2",
@@ -5013,12 +5223,28 @@
 			}
 		},
 		"node_modules/asn1.js/node_modules/bn.js": {
-			"version": "4.12.2",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-			"integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+			"version": "4.12.3",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+			"integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true
+		},
+		"node_modules/asn1js": {
+			"version": "3.0.10",
+			"resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+			"integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"pvtsutils": "^1.3.6",
+				"pvutils": "^1.1.5",
+				"tslib": "^2.8.1"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
 		},
 		"node_modules/assert": {
 			"version": "2.1.0",
@@ -5081,14 +5307,15 @@
 			}
 		},
 		"node_modules/axios": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-			"integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+			"version": "1.18.0",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+			"integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
 			"license": "MIT",
 			"dependencies": {
-				"follow-redirects": "^1.15.6",
-				"form-data": "^4.0.4",
-				"proxy-from-env": "^1.1.0"
+				"follow-redirects": "^1.16.0",
+				"form-data": "^4.0.5",
+				"https-proxy-agent": "^5.0.1",
+				"proxy-from-env": "^2.1.0"
 			}
 		},
 		"node_modules/babel-loader": {
@@ -5198,6 +5425,19 @@
 			"license": "MIT",
 			"peer": true
 		},
+		"node_modules/baseline-browser-mapping": {
+			"version": "2.10.38",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
+			"integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"bin": {
+				"baseline-browser-mapping": "dist/cli.cjs"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
 		"node_modules/batch": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -5242,33 +5482,33 @@
 			"license": "MIT"
 		},
 		"node_modules/bn.js": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.2.tgz",
-			"integrity": "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==",
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
+			"integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true
 		},
 		"node_modules/body-parser": {
-			"version": "1.20.3",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
-			"integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+			"version": "1.20.5",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+			"integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"bytes": "3.1.2",
+				"bytes": "~3.1.2",
 				"content-type": "~1.0.5",
 				"debug": "2.6.9",
 				"depd": "2.0.0",
-				"destroy": "1.2.0",
-				"http-errors": "2.0.0",
-				"iconv-lite": "0.4.24",
-				"on-finished": "2.4.1",
-				"qs": "6.13.0",
-				"raw-body": "2.5.2",
+				"destroy": "~1.2.0",
+				"http-errors": "~2.0.1",
+				"iconv-lite": "~0.4.24",
+				"on-finished": "~2.4.1",
+				"qs": "~6.15.1",
+				"raw-body": "~2.5.3",
 				"type-is": "~1.6.18",
-				"unpipe": "1.0.0"
+				"unpipe": "~1.0.0"
 			},
 			"engines": {
 				"node": ">= 0.8",
@@ -5294,23 +5534,6 @@
 			"license": "MIT",
 			"peer": true
 		},
-		"node_modules/body-parser/node_modules/qs": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-			"integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"peer": true,
-			"dependencies": {
-				"side-channel": "^1.0.6"
-			},
-			"engines": {
-				"node": ">=0.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/bonjour-service": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.3.0.tgz",
@@ -5332,9 +5555,9 @@
 			"peer": true
 		},
 		"node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+			"integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0"
@@ -5421,26 +5644,25 @@
 			}
 		},
 		"node_modules/browserify-sign": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.3.tgz",
-			"integrity": "sha512-JWCZW6SKhfhjJxO8Tyiiy+XYB7cqd2S5/+WeYHsKdNKFlCBhKbblba1A/HN/90YwtxKc8tCErjffZl++UNmGiw==",
+			"version": "4.2.6",
+			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.6.tgz",
+			"integrity": "sha512-sd+Q65fjlWCYWtZKXiKfrUc8d+4jtp/8f0W2NkwzLtoW4bI6UDnWusLWIurHnmurW0XShIRxpwiOX4EoPtXUAg==",
 			"dev": true,
 			"license": "ISC",
 			"peer": true,
 			"dependencies": {
-				"bn.js": "^5.2.1",
-				"browserify-rsa": "^4.1.0",
+				"bn.js": "^5.2.3",
+				"browserify-rsa": "^4.1.1",
 				"create-hash": "^1.2.0",
 				"create-hmac": "^1.1.7",
-				"elliptic": "^6.5.5",
-				"hash-base": "~3.0",
+				"elliptic": "^6.6.1",
 				"inherits": "^2.0.4",
-				"parse-asn1": "^5.1.7",
+				"parse-asn1": "^5.1.9",
 				"readable-stream": "^2.3.8",
 				"safe-buffer": "^5.2.1"
 			},
 			"engines": {
-				"node": ">= 0.12"
+				"node": ">= 0.10"
 			}
 		},
 		"node_modules/browserify-sign/node_modules/isarray": {
@@ -5507,9 +5729,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.25.3",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.3.tgz",
-			"integrity": "sha512-cDGv1kkDI4/0e5yON9yM5G/0A5u8sf5TnmdX5C9qHzI9PPu++sQ9zjm1k9NiOrf3riY4OkK0zSGqfvJyJsgCBQ==",
+			"version": "4.28.2",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+			"integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -5527,10 +5749,11 @@
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001735",
-				"electron-to-chromium": "^1.5.204",
-				"node-releases": "^2.0.19",
-				"update-browserslist-db": "^1.1.3"
+				"baseline-browser-mapping": "^2.10.12",
+				"caniuse-lite": "^1.0.30001782",
+				"electron-to-chromium": "^1.5.328",
+				"node-releases": "^2.0.36",
+				"update-browserslist-db": "^1.2.3"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -5661,6 +5884,17 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/bytestreamjs": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
+			"integrity": "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
 		"node_modules/cacheable": {
 			"version": "1.10.4",
 			"resolved": "https://registry.npmjs.org/cacheable/-/cacheable-1.10.4.tgz",
@@ -5753,9 +5987,9 @@
 			"license": "MIT"
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001737",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001737.tgz",
-			"integrity": "sha512-BiloLiXtQNrY5UyF0+1nSJLXUENuhka2pzy2Fx5pGxqavdrxSCW4U6Pn/PoG3Efspi2frRbHpBV2XsrPE6EDlw==",
+			"version": "1.0.30001799",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+			"integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -6131,9 +6365,9 @@
 			"peer": true
 		},
 		"node_modules/cookie": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
-			"integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -6142,17 +6376,17 @@
 			}
 		},
 		"node_modules/cookie-signature": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-			"integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+			"integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true
 		},
 		"node_modules/core-js": {
-			"version": "3.37.0",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.37.0.tgz",
-			"integrity": "sha512-fu5vHevQ8ZG4og+LXug8ulUtVxjOcEYvifJr7L5Bfq9GOztVqsKd9/59hUk2ZSbCrS3BqUr3EpaYGIYzq7g3Ug==",
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+			"integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"funding": {
@@ -6224,9 +6458,9 @@
 			}
 		},
 		"node_modules/create-ecdh/node_modules/bn.js": {
-			"version": "4.12.2",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-			"integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+			"version": "4.12.3",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+			"integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true
@@ -6717,9 +6951,9 @@
 			}
 		},
 		"node_modules/diffie-hellman/node_modules/bn.js": {
-			"version": "4.12.2",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-			"integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+			"version": "4.12.3",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+			"integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true
@@ -6827,9 +7061,9 @@
 			}
 		},
 		"node_modules/dompurify": {
-			"version": "3.2.6",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
-			"integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+			"version": "3.4.11",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+			"integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"optionalDependencies": {
 				"@types/trusted-types": "^2.0.7"
@@ -6874,9 +7108,9 @@
 			"peer": true
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.208",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.208.tgz",
-			"integrity": "sha512-ozZyibehoe7tOhNaf16lKmljVf+3npZcJIEbJRVftVsmAg5TeA1mGS9dVCZzOwr2xT7xK15V0p7+GZqSPgkuPg==",
+			"version": "1.5.376",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.376.tgz",
+			"integrity": "sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==",
 			"license": "ISC",
 			"peer": true
 		},
@@ -6898,17 +7132,17 @@
 			}
 		},
 		"node_modules/elliptic/node_modules/bn.js": {
-			"version": "4.12.2",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-			"integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+			"version": "4.12.3",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+			"integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true
 		},
 		"node_modules/emoji-mart-vue-fast": {
-			"version": "15.0.4",
-			"resolved": "https://registry.npmjs.org/emoji-mart-vue-fast/-/emoji-mart-vue-fast-15.0.4.tgz",
-			"integrity": "sha512-OjuxqoMJRTTG7Vevz0mR1ZnqY1DI8gGnmoskuuC8qL8VwwTjrGdwAO4WRWtAUN8P6Di7kxvY6cUgNETNFmbP4A==",
+			"version": "15.0.5",
+			"resolved": "https://registry.npmjs.org/emoji-mart-vue-fast/-/emoji-mart-vue-fast-15.0.5.tgz",
+			"integrity": "sha512-wnxLor8ggpqshoOPwIc33MdOC3A1XFeDLgUwYLPtNPL8VeAtXJAVrnFq1CN5PeCYAFoLo4IufHQZ9CfHD4IZiw==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@babel/runtime": "^7.18.6",
@@ -6947,14 +7181,14 @@
 			}
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "5.18.3",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.3.tgz",
-			"integrity": "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==",
+			"version": "5.24.0",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.0.tgz",
+			"integrity": "sha512-SkE2t82KlkkxQRVMVLAGKxLfORGQfrkx5dkj+vlgXRVNEdPc4eZcR+J/Fvj8C+yKSFH5L0q3NFlyufOVQnCcYQ==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"graceful-fs": "^4.2.4",
-				"tapable": "^2.2.0"
+				"tapable": "^2.3.3"
 			},
 			"engines": {
 				"node": ">=10.13.0"
@@ -7099,9 +7333,9 @@
 			}
 		},
 		"node_modules/es-module-lexer": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-			"integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+			"integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
 			"license": "MIT",
 			"peer": true
 		},
@@ -7479,9 +7713,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -7516,9 +7750,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-import/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"peer": true,
@@ -7599,9 +7833,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-n/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -7611,9 +7845,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-n/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"peer": true,
@@ -7744,9 +7978,9 @@
 			}
 		},
 		"node_modules/eslint/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -7799,9 +8033,9 @@
 			}
 		},
 		"node_modules/eslint/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"peer": true,
@@ -7937,9 +8171,9 @@
 			}
 		},
 		"node_modules/eventemitter3": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-			"integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+			"integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
 			"license": "MIT"
 		},
 		"node_modules/events": {
@@ -7965,41 +8199,41 @@
 			}
 		},
 		"node_modules/express": {
-			"version": "4.21.2",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
-			"integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+			"version": "4.22.2",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+			"integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"accepts": "~1.3.8",
 				"array-flatten": "1.1.1",
-				"body-parser": "1.20.3",
-				"content-disposition": "0.5.4",
+				"body-parser": "~1.20.5",
+				"content-disposition": "~0.5.4",
 				"content-type": "~1.0.4",
-				"cookie": "0.7.1",
-				"cookie-signature": "1.0.6",
+				"cookie": "~0.7.1",
+				"cookie-signature": "~1.0.6",
 				"debug": "2.6.9",
 				"depd": "2.0.0",
 				"encodeurl": "~2.0.0",
 				"escape-html": "~1.0.3",
 				"etag": "~1.8.1",
-				"finalhandler": "1.3.1",
-				"fresh": "0.5.2",
-				"http-errors": "2.0.0",
+				"finalhandler": "~1.3.1",
+				"fresh": "~0.5.2",
+				"http-errors": "~2.0.0",
 				"merge-descriptors": "1.0.3",
 				"methods": "~1.1.2",
-				"on-finished": "2.4.1",
+				"on-finished": "~2.4.1",
 				"parseurl": "~1.3.3",
-				"path-to-regexp": "0.1.12",
+				"path-to-regexp": "~0.1.12",
 				"proxy-addr": "~2.0.7",
-				"qs": "6.13.0",
+				"qs": "~6.15.1",
 				"range-parser": "~1.2.1",
 				"safe-buffer": "5.2.1",
-				"send": "0.19.0",
-				"serve-static": "1.16.2",
+				"send": "~0.19.0",
+				"serve-static": "~1.16.2",
 				"setprototypeof": "1.2.0",
-				"statuses": "2.0.1",
+				"statuses": "~2.0.1",
 				"type-is": "~1.6.18",
 				"utils-merge": "1.0.1",
 				"vary": "~1.1.2"
@@ -8030,23 +8264,6 @@
 			"dev": true,
 			"license": "MIT",
 			"peer": true
-		},
-		"node_modules/express/node_modules/qs": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-			"integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"peer": true,
-			"dependencies": {
-				"side-channel": "^1.0.6"
-			},
-			"engines": {
-				"node": ">=0.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
 		},
 		"node_modules/extend": {
 			"version": "3.0.2",
@@ -8107,9 +8324,9 @@
 			"peer": true
 		},
 		"node_modules/fast-uri": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-			"integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
 			"funding": [
 				{
 					"type": "github",
@@ -8122,10 +8339,10 @@
 			],
 			"license": "BSD-3-Clause"
 		},
-		"node_modules/fast-xml-parser": {
-			"version": "4.5.3",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
-			"integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
+		"node_modules/fast-xml-builder": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+			"integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
 			"funding": [
 				{
 					"type": "github",
@@ -8133,6 +8350,24 @@
 				}
 			],
 			"license": "MIT",
+			"dependencies": {
+				"path-expression-matcher": "^1.5.0",
+				"xml-naming": "^0.1.0"
+			}
+		},
+		"node_modules/fast-xml-parser": {
+			"version": "4.5.3",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
+			"integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"strnum": "^1.1.1"
 			},
@@ -8226,9 +8461,9 @@
 			}
 		},
 		"node_modules/finalhandler": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
-			"integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+			"integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -8236,9 +8471,9 @@
 				"debug": "2.6.9",
 				"encodeurl": "~2.0.0",
 				"escape-html": "~1.0.3",
-				"on-finished": "2.4.1",
+				"on-finished": "~2.4.1",
 				"parseurl": "~1.3.3",
-				"statuses": "2.0.1",
+				"statuses": "~2.0.2",
 				"unpipe": "~1.0.0"
 			},
 			"engines": {
@@ -8310,9 +8545,9 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-			"integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
 			"dev": true,
 			"license": "ISC",
 			"peer": true
@@ -8346,18 +8581,18 @@
 			}
 		},
 		"node_modules/focus-trap": {
-			"version": "7.6.5",
-			"resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.5.tgz",
-			"integrity": "sha512-7Ke1jyybbbPZyZXFxEftUtxFGLMpE2n6A+z//m4CRDlj0hW+o3iYSmh8nFlYMurOiJVDmJRilUQtJr08KfIxlg==",
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.8.0.tgz",
+			"integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
 			"license": "MIT",
 			"dependencies": {
-				"tabbable": "^6.2.0"
+				"tabbable": "^6.4.0"
 			}
 		},
 		"node_modules/follow-redirects": {
-			"version": "1.15.11",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-			"integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+			"integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
 			"funding": [
 				{
 					"type": "individual",
@@ -8392,16 +8627,16 @@
 			}
 		},
 		"node_modules/form-data": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-			"integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+			"integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
 			"license": "MIT",
 			"dependencies": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
 				"es-set-tostringtag": "^2.1.0",
-				"hasown": "^2.0.2",
-				"mime-types": "^2.1.12"
+				"hasown": "^2.0.4",
+				"mime-types": "^2.1.35"
 			},
 			"engines": {
 				"node": ">= 6"
@@ -8651,9 +8886,9 @@
 			"peer": true
 		},
 		"node_modules/glob/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -8663,9 +8898,9 @@
 			}
 		},
 		"node_modules/glob/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"peer": true,
@@ -8933,9 +9168,9 @@
 			}
 		},
 		"node_modules/hasown": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+			"integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
 			"license": "MIT",
 			"dependencies": {
 				"function-bind": "^1.1.2"
@@ -9145,21 +9380,25 @@
 			"peer": true
 		},
 		"node_modules/http-errors": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-			"integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+			"integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"depd": "2.0.0",
-				"inherits": "2.0.4",
-				"setprototypeof": "1.2.0",
-				"statuses": "2.0.1",
-				"toidentifier": "1.0.1"
+				"depd": "~2.0.0",
+				"inherits": "~2.0.4",
+				"setprototypeof": "~1.2.0",
+				"statuses": "~2.0.2",
+				"toidentifier": "~1.0.1"
 			},
 			"engines": {
 				"node": ">= 0.8"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/http-parser-js": {
@@ -9187,9 +9426,9 @@
 			}
 		},
 		"node_modules/http-proxy-middleware": {
-			"version": "2.0.9",
-			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-			"integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+			"version": "2.0.10",
+			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz",
+			"integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -9242,6 +9481,19 @@
 			"license": "MIT",
 			"peer": true
 		},
+		"node_modules/https-proxy-agent": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "6",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/hyperdyperid": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
@@ -9252,12 +9504,6 @@
 			"engines": {
 				"node": ">=10.18"
 			}
-		},
-		"node_modules/ical.js": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/ical.js/-/ical.js-2.2.1.tgz",
-			"integrity": "sha512-yK/UlPbEs316igb/tjRgbFA8ZV75rCsBJp/hWOatpyaPNlgw0dGDmU+FoicOcwX4xXkeXOkYiOmCqNPFpNPkQg==",
-			"license": "MPL-2.0"
 		},
 		"node_modules/iconv-lite": {
 			"version": "0.4.24",
@@ -9319,9 +9565,9 @@
 			}
 		},
 		"node_modules/immutable": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.3.tgz",
-			"integrity": "sha512-+chQdDfvscSF1SJqv2gn4SRO2ZyS3xL3r7IW/wWEEzrzLisnOlKiQu5ytC/BVNcS15C39WT2Hg/bjKjDMcu+zg==",
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.6.tgz",
+			"integrity": "sha512-q1swsS8K7L8usSHuOqF2TAoCCkonYz0SG38wLAggaa4Wml70zixIvt2ql4coQ2C2B3hTjltJry4r6bULwgAXLQ==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true
@@ -10042,6 +10288,18 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/is-unsafe": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-1.0.1.tgz",
+			"integrity": "sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT"
+		},
 		"node_modules/is-weakmap": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
@@ -10194,10 +10452,20 @@
 			"peer": true
 		},
 		"node_modules/js-yaml": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+			"integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodeca"
+				}
+			],
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -10244,6 +10512,7 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
 			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+			"dev": true,
 			"license": "MIT",
 			"peer": true
 		},
@@ -10308,15 +10577,15 @@
 			"peer": true
 		},
 		"node_modules/launch-editor": {
-			"version": "2.11.1",
-			"resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.11.1.tgz",
-			"integrity": "sha512-SEET7oNfgSaB6Ym0jufAdCeo3meJVeCaaDyzRygy0xsp2BFKCprcfHljTq4QkzTLUxEKkFK6OK4811YM2oSrRg==",
+			"version": "2.14.1",
+			"resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.14.1.tgz",
+			"integrity": "sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"picocolors": "^1.1.1",
-				"shell-quote": "^1.8.3"
+				"shell-quote": "^1.8.4"
 			}
 		},
 		"node_modules/layerr": {
@@ -10365,13 +10634,17 @@
 			"peer": true
 		},
 		"node_modules/loader-runner": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
-			"integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.2.tgz",
+			"integrity": "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
 				"node": ">=6.11.5"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
 			}
 		},
 		"node_modules/loader-utils": {
@@ -10418,9 +10691,9 @@
 			}
 		},
 		"node_modules/lodash": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true
@@ -10613,9 +10886,9 @@
 			}
 		},
 		"node_modules/mdast-util-to-hast": {
-			"version": "13.2.0",
-			"resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz",
-			"integrity": "sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==",
+			"version": "13.2.1",
+			"resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+			"integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/hast": "^3.0.0",
@@ -11230,9 +11503,9 @@
 			}
 		},
 		"node_modules/miller-rabin/node_modules/bn.js": {
-			"version": "4.12.2",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-			"integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+			"version": "4.12.3",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+			"integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true
@@ -11289,12 +11562,12 @@
 			"peer": true
 		},
 		"node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
 			"license": "ISC",
 			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"brace-expansion": "^2.0.2"
 			},
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
@@ -11343,9 +11616,9 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.11",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+			"version": "3.3.14",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.14.tgz",
+			"integrity": "sha512-U9kYi5bpVMEI31yC8iw4bJJp0avcHXA0W8/wNfLfnvJYzihQo2ZRPYPvpAAd570HAcCBjCTN7vnr+v4StKl1IQ==",
 			"funding": [
 				{
 					"type": "github",
@@ -11456,17 +11729,6 @@
 				"url": "https://opencollective.com/node-fetch"
 			}
 		},
-		"node_modules/node-forge": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-			"integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
-			"dev": true,
-			"license": "(BSD-3-Clause OR GPL-2.0)",
-			"peer": true,
-			"engines": {
-				"node": ">= 6.13.0"
-			}
-		},
 		"node_modules/node-polyfill-webpack-plugin": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/node-polyfill-webpack-plugin/-/node-polyfill-webpack-plugin-4.0.0.tgz",
@@ -11522,11 +11784,14 @@
 			}
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.19",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-			"integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+			"version": "2.0.48",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
+			"integrity": "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==",
 			"license": "MIT",
-			"peer": true
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
@@ -11818,16 +12083,16 @@
 			}
 		},
 		"node_modules/p-queue": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.1.0.tgz",
-			"integrity": "sha512-mxLDbbGIBEXTJL0zEx8JIylaj3xQ7Z/7eEVjcF9fJX4DBiH9oqe+oahYnlKKxm0Ci9TlWTyhSHgygxMxjIB2jw==",
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.0.tgz",
+			"integrity": "sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==",
 			"license": "MIT",
 			"dependencies": {
-				"eventemitter3": "^5.0.1",
-				"p-timeout": "^6.1.2"
+				"eventemitter3": "^5.0.4",
+				"p-timeout": "^7.0.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -11853,12 +12118,12 @@
 			}
 		},
 		"node_modules/p-timeout": {
-			"version": "6.1.4",
-			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
-			"integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+			"integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=14.16"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -11898,9 +12163,9 @@
 			}
 		},
 		"node_modules/parse-asn1": {
-			"version": "5.1.7",
-			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.7.tgz",
-			"integrity": "sha512-CTM5kuWR3sx9IFamcl5ErfPl6ea/N8IYwiJ+vpeB2g+1iknv7zBl5uPwbMbRVznRVbrNY6lGuDoE5b30grmbqg==",
+			"version": "5.1.9",
+			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.9.tgz",
+			"integrity": "sha512-fIYNuZ/HastSb80baGOuPRo1O9cf4baWw5WsAp7dBuUzeTD/BoaG8sVTdlPFksBE2lF21dN+A1AnrpIjSWqHHg==",
 			"dev": true,
 			"license": "ISC",
 			"peer": true,
@@ -11908,8 +12173,7 @@
 				"asn1.js": "^4.10.1",
 				"browserify-aes": "^1.2.0",
 				"evp_bytestokey": "^1.0.3",
-				"hash-base": "~3.0",
-				"pbkdf2": "^3.1.2",
+				"pbkdf2": "^3.1.5",
 				"safe-buffer": "^5.2.1"
 			},
 			"engines": {
@@ -11966,6 +12230,21 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/path-expression-matcher": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.0.tgz",
+			"integrity": "sha512-e5y7RCLHKjemsgQ4eqGJtPyr10ILz25HO7flzxhTV8bgvd5yHx98DGtCAtbVW9f2TqnYI/gEVZd+vz7snrdPTw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
 		"node_modules/path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -12003,9 +12282,9 @@
 			"license": "ISC"
 		},
 		"node_modules/path-to-regexp": {
-			"version": "0.1.12",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-			"integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+			"integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true
@@ -12021,59 +12300,22 @@
 			}
 		},
 		"node_modules/pbkdf2": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.3.tgz",
-			"integrity": "sha512-wfRLBZ0feWRhCIkoMB6ete7czJcnNnqRpcoWQBLqatqXXmelSRqfdDK4F3u9T2s2cXas/hQJcryI/4lAL+XTlA==",
+			"version": "3.1.6",
+			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.6.tgz",
+			"integrity": "sha512-BT6eelPB1EyGHo8pC0o9Bl6k6SYVhKO1jEbd3lcTrtr7XHdjP8BW1YpfCV3G9Kwkxgattk+S5q2/RvuttCsS1g==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"create-hash": "~1.1.3",
+				"create-hash": "^1.2.0",
 				"create-hmac": "^1.1.7",
-				"ripemd160": "=2.0.1",
+				"ripemd160": "^2.0.3",
 				"safe-buffer": "^5.2.1",
-				"sha.js": "^2.4.11",
-				"to-buffer": "^1.2.0"
+				"sha.js": "^2.4.12",
+				"to-buffer": "^1.2.2"
 			},
 			"engines": {
-				"node": ">=0.12"
-			}
-		},
-		"node_modules/pbkdf2/node_modules/create-hash": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
-			"integrity": "sha512-snRpch/kwQhcdlnZKYanNF1m0RDlrCdSKQaH87w1FCFPVPNCQ/Il9QJKAX2jVBZddRdaHBMC+zXa9Gw9tmkNUA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"cipher-base": "^1.0.1",
-				"inherits": "^2.0.1",
-				"ripemd160": "^2.0.0",
-				"sha.js": "^2.4.0"
-			}
-		},
-		"node_modules/pbkdf2/node_modules/hash-base": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
-			"integrity": "sha512-0TROgQ1/SxE6KmxWSvXHvRj90/Xo1JvZShofnYF+f6ZsGtR4eES7WfrQzPalmyagfKZCXpVnitiRebZulWsbiw==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"inherits": "^2.0.1"
-			}
-		},
-		"node_modules/pbkdf2/node_modules/ripemd160": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
-			"integrity": "sha512-J7f4wutN8mdbV08MJnXibYpCOPHR+yzy+iQ/AsjMv2j8cLavQ8VGagDFUwwTAdF8FmRKVeNpbTTEwNHCW1g94w==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"hash-base": "^2.0.0",
-				"inherits": "^2.0.1"
+				"node": ">= 0.10"
 			}
 		},
 		"node_modules/picocolors": {
@@ -12083,9 +12325,9 @@
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -12169,6 +12411,25 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/pkijs": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.4.0.tgz",
+			"integrity": "sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"@noble/hashes": "1.4.0",
+				"asn1js": "^3.0.6",
+				"bytestreamjs": "^2.0.1",
+				"pvtsutils": "^1.3.6",
+				"pvutils": "^1.1.3",
+				"tslib": "^2.8.1"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
 		"node_modules/possible-typed-array-names": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -12181,9 +12442,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.6",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-			"integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+			"version": "8.5.15",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+			"integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -12200,7 +12461,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.11",
+				"nanoid": "^3.3.12",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},
@@ -12489,10 +12750,13 @@
 			}
 		},
 		"node_modules/proxy-from-env": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-			"license": "MIT"
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+			"integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			}
 		},
 		"node_modules/pseudomap": {
 			"version": "1.0.2",
@@ -12517,9 +12781,9 @@
 			}
 		},
 		"node_modules/public-encrypt/node_modules/bn.js": {
-			"version": "4.12.2",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-			"integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+			"version": "4.12.3",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+			"integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true
@@ -12535,10 +12799,32 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/pvtsutils": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+			"integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/pvutils": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+			"integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
 		"node_modules/qs": {
-			"version": "6.14.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-			"integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+			"version": "6.15.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+			"integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"peer": true,
@@ -12593,6 +12879,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
 			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -12623,17 +12910,17 @@
 			}
 		},
 		"node_modules/raw-body": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-			"integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+			"version": "2.5.3",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+			"integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"bytes": "3.1.2",
-				"http-errors": "2.0.0",
-				"iconv-lite": "0.4.24",
-				"unpipe": "1.0.0"
+				"bytes": "~3.1.2",
+				"http-errors": "~2.0.1",
+				"iconv-lite": "~0.4.24",
+				"unpipe": "~1.0.0"
 			},
 			"engines": {
 				"node": ">= 0.8"
@@ -12685,6 +12972,14 @@
 			"engines": {
 				"node": ">= 10.13.0"
 			}
+		},
+		"node_modules/reflect-metadata": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+			"integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true
 		},
 		"node_modules/reflect.getprototypeof": {
 			"version": "1.0.10",
@@ -13170,16 +13465,88 @@
 			}
 		},
 		"node_modules/ripemd160": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
-			"integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.3.tgz",
+			"integrity": "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"hash-base": "^3.0.0",
-				"inherits": "^2.0.1"
+				"hash-base": "^3.1.2",
+				"inherits": "^2.0.4"
+			},
+			"engines": {
+				"node": ">= 0.8"
 			}
+		},
+		"node_modules/ripemd160/node_modules/hash-base": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.2.tgz",
+			"integrity": "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"inherits": "^2.0.4",
+				"readable-stream": "^2.3.8",
+				"safe-buffer": "^5.2.1",
+				"to-buffer": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/ripemd160/node_modules/isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/ripemd160/node_modules/readable-stream": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			}
+		},
+		"node_modules/ripemd160/node_modules/readable-stream/node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/ripemd160/node_modules/string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"safe-buffer": "~5.1.0"
+			}
+		},
+		"node_modules/ripemd160/node_modules/string_decoder/node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/run-applescript": {
 			"version": "7.0.0",
@@ -13244,6 +13611,7 @@
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
 			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -13371,15 +13739,18 @@
 			}
 		},
 		"node_modules/sax": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
-			"integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
-			"license": "ISC"
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+			"integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=11.0.0"
+			}
 		},
 		"node_modules/schema-utils": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.2.tgz",
-			"integrity": "sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+			"integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/json-schema": "^7.0.9",
@@ -13396,9 +13767,9 @@
 			}
 		},
 		"node_modules/schema-utils/node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
@@ -13438,18 +13809,18 @@
 			"peer": true
 		},
 		"node_modules/selfsigned": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.4.1.tgz",
-			"integrity": "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-5.5.0.tgz",
+			"integrity": "sha512-ftnu3TW4+3eBfLRFnDEkzGxSF/10BJBkaLJuBHZX0kiPS7bRdlpZGu6YGt4KngMkdTwJE6MbjavFpqHvqVt+Ew==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@types/node-forge": "^1.3.0",
-				"node-forge": "^1"
+				"@peculiar/x509": "^1.14.2",
+				"pkijs": "^3.3.3"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=18"
 			}
 		},
 		"node_modules/semver": {
@@ -13464,9 +13835,9 @@
 			}
 		},
 		"node_modules/send": {
-			"version": "0.19.0",
-			"resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
-			"integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+			"version": "0.19.2",
+			"resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+			"integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -13474,16 +13845,16 @@
 				"debug": "2.6.9",
 				"depd": "2.0.0",
 				"destroy": "1.2.0",
-				"encodeurl": "~1.0.2",
+				"encodeurl": "~2.0.0",
 				"escape-html": "~1.0.3",
 				"etag": "~1.8.1",
-				"fresh": "0.5.2",
-				"http-errors": "2.0.0",
+				"fresh": "~0.5.2",
+				"http-errors": "~2.0.1",
 				"mime": "1.6.0",
 				"ms": "2.1.3",
-				"on-finished": "2.4.1",
+				"on-finished": "~2.4.1",
 				"range-parser": "~1.2.1",
-				"statuses": "2.0.1"
+				"statuses": "~2.0.2"
 			},
 			"engines": {
 				"node": ">= 0.8.0"
@@ -13507,27 +13878,6 @@
 			"dev": true,
 			"license": "MIT",
 			"peer": true
-		},
-		"node_modules/send/node_modules/encodeurl": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-			"integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/serialize-javascript": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-			"integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-			"license": "BSD-3-Clause",
-			"peer": true,
-			"dependencies": {
-				"randombytes": "^2.1.0"
-			}
 		},
 		"node_modules/serve-index": {
 			"version": "1.9.1",
@@ -13624,9 +13974,9 @@
 			}
 		},
 		"node_modules/serve-static": {
-			"version": "1.16.2",
-			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
-			"integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+			"version": "1.16.3",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+			"integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -13634,7 +13984,7 @@
 				"encodeurl": "~2.0.0",
 				"escape-html": "~1.0.3",
 				"parseurl": "~1.3.3",
-				"send": "0.19.0"
+				"send": "~0.19.1"
 			},
 			"engines": {
 				"node": ">= 0.8.0"
@@ -13770,9 +14120,9 @@
 			}
 		},
 		"node_modules/shell-quote": {
-			"version": "1.8.3",
-			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-			"integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+			"version": "1.8.4",
+			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+			"integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -14063,9 +14413,9 @@
 			"peer": true
 		},
 		"node_modules/statuses": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-			"integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+			"integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -14327,18 +14677,20 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
 			"integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
 					"url": "https://github.com/sponsors/NaturalIntelligence"
 				}
 			],
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/strtok3": {
-			"version": "10.3.4",
-			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.4.tgz",
-			"integrity": "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==",
+			"version": "10.3.5",
+			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+			"integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
 			"license": "MIT",
 			"dependencies": {
 				"@tokenizer/token": "^0.3.0"
@@ -14813,9 +15165,9 @@
 			"peer": true
 		},
 		"node_modules/tabbable": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
-			"integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+			"integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
 			"license": "MIT"
 		},
 		"node_modules/table": {
@@ -14837,9 +15189,9 @@
 			}
 		},
 		"node_modules/table/node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -14863,9 +15215,9 @@
 			"peer": true
 		},
 		"node_modules/tapable": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.3.tgz",
-			"integrity": "sha512-ZL6DDuAlRlLGghwcfmSn9sK3Hr6ArtyudlSAiCqQ6IfE+b+HHbydbYDIG15IfS5do+7XQQBdBiubF/cV2dnDzg==",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+			"integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -14877,14 +15229,14 @@
 			}
 		},
 		"node_modules/terser": {
-			"version": "5.43.1",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.43.1.tgz",
-			"integrity": "sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==",
+			"version": "5.48.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.48.0.tgz",
+			"integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
 			"license": "BSD-2-Clause",
 			"peer": true,
 			"dependencies": {
 				"@jridgewell/source-map": "^0.3.3",
-				"acorn": "^8.14.0",
+				"acorn": "^8.15.0",
 				"commander": "^2.20.0",
 				"source-map-support": "~0.5.20"
 			},
@@ -14896,16 +15248,15 @@
 			}
 		},
 		"node_modules/terser-webpack-plugin": {
-			"version": "5.3.14",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.14.tgz",
-			"integrity": "sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==",
+			"version": "5.6.1",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.6.1.tgz",
+			"integrity": "sha512-201R5j+sJpK8nFWwKVyNfZot8FaJbLZDq5evriVzbV1wDtSXDjRUDRfJzHpAaxFDMEhsZL1QkeqM61wgsS3KaQ==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.25",
 				"jest-worker": "^27.4.5",
 				"schema-utils": "^4.3.0",
-				"serialize-javascript": "^6.0.2",
 				"terser": "^5.31.1"
 			},
 			"engines": {
@@ -14919,10 +15270,37 @@
 				"webpack": "^5.1.0"
 			},
 			"peerDependenciesMeta": {
+				"@minify-html/node": {
+					"optional": true
+				},
 				"@swc/core": {
 					"optional": true
 				},
+				"@swc/css": {
+					"optional": true
+				},
+				"@swc/html": {
+					"optional": true
+				},
+				"clean-css": {
+					"optional": true
+				},
+				"cssnano": {
+					"optional": true
+				},
+				"csso": {
+					"optional": true
+				},
 				"esbuild": {
+					"optional": true
+				},
+				"html-minifier-terser": {
+					"optional": true
+				},
+				"lightningcss": {
+					"optional": true
+				},
+				"postcss": {
 					"optional": true
 				},
 				"uglify-js": {
@@ -15053,9 +15431,9 @@
 			}
 		},
 		"node_modules/tinyglobby/node_modules/picomatch": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -15067,9 +15445,9 @@
 			}
 		},
 		"node_modules/to-buffer": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.1.tgz",
-			"integrity": "sha512-tB82LpAIWjhLYbqjx3X4zEeHN6M8CiuOEy2JY8SEQVdYRe3CCHOFaqrBW1doLDrfpWhplcW7BL+bO3/6S3pcDQ==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+			"integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -15242,6 +15620,28 @@
 			"license": "0BSD",
 			"peer": true
 		},
+		"node_modules/tsyringe": {
+			"version": "4.10.0",
+			"resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+			"integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^1.9.3"
+			},
+			"engines": {
+				"node": ">= 6.0.0"
+			}
+		},
+		"node_modules/tsyringe/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+			"dev": true,
+			"license": "0BSD",
+			"peer": true
+		},
 		"node_modules/tty-browserify": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
@@ -15391,9 +15791,9 @@
 			}
 		},
 		"node_modules/typescript-event-target": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/typescript-event-target/-/typescript-event-target-1.1.1.tgz",
-			"integrity": "sha512-dFSOFBKV6uwaloBCCUhxlD3Pr/P1a/tJdcmPrTXCHlEFD3faj0mztjcGn6VBAhQ0/Bdy8K3VWrrqwbt/ffsYsg==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/typescript-event-target/-/typescript-event-target-1.1.2.tgz",
+			"integrity": "sha512-TvkrTUpv7gCPlcnSoEwUVUBwsdheKm+HF5u2tPAKubkIGMfovdSizCTaZRY/NhR8+Ijy8iZZUapbVQAsNrkFrw==",
 			"license": "MIT"
 		},
 		"node_modules/unbox-primitive": {
@@ -15571,9 +15971,9 @@
 			}
 		},
 		"node_modules/unist-util-visit-parents": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
-			"integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+			"integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/unist": "^3.0.0",
@@ -15632,9 +16032,9 @@
 			}
 		},
 		"node_modules/update-browserslist-db": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-			"integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+			"integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -16010,13 +16410,12 @@
 			}
 		},
 		"node_modules/watchpack": {
-			"version": "2.4.4",
-			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.4.tgz",
-			"integrity": "sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==",
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.2.tgz",
+			"integrity": "sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"glob-to-regexp": "^0.4.1",
 				"graceful-fs": "^4.1.2"
 			},
 			"engines": {
@@ -16054,20 +16453,20 @@
 			}
 		},
 		"node_modules/webdav": {
-			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/webdav/-/webdav-5.8.0.tgz",
-			"integrity": "sha512-iuFG7NamJ41Oshg4930iQgfIpRrUiatPWIekeznYgEf2EOraTRcDPTjy7gIOMtkdpKTaqPk1E68NO5PAGtJahA==",
+			"version": "5.10.0",
+			"resolved": "https://registry.npmjs.org/webdav/-/webdav-5.10.0.tgz",
+			"integrity": "sha512-fVPuRLtcduVGvSO7Tn/6TQCzIvI/g6BO/+xPRctCvi/GytYpjn4czxWbh4HsArsdom9qz9BI63k9/v2HBUui1A==",
 			"license": "MIT",
 			"dependencies": {
 				"@buttercup/fetch": "^0.2.1",
 				"base-64": "^1.0.0",
 				"byte-length": "^1.0.2",
-				"entities": "^6.0.0",
-				"fast-xml-parser": "^4.5.1",
+				"entities": "^6.0.1",
+				"fast-xml-parser": "^5.7.2",
 				"hot-patcher": "^2.0.1",
 				"layerr": "^3.0.0",
 				"md5": "^2.3.0",
-				"minimatch": "^9.0.5",
+				"minimatch": "^9.0.9",
 				"nested-property": "^4.0.0",
 				"node-fetch": "^3.3.2",
 				"path-posix": "^1.0.0",
@@ -16090,38 +16489,74 @@
 				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
+		"node_modules/webdav/node_modules/fast-xml-parser": {
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.9.3.tgz",
+			"integrity": "sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@nodable/entities": "^2.2.0",
+				"fast-xml-builder": "^1.2.0",
+				"is-unsafe": "^1.0.1",
+				"path-expression-matcher": "^1.5.0",
+				"strnum": "^2.4.1",
+				"xml-naming": "^0.1.0"
+			},
+			"bin": {
+				"fxparser": "src/cli/cli.js"
+			}
+		},
+		"node_modules/webdav/node_modules/strnum": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+			"integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"anynum": "^1.0.1"
+			}
+		},
 		"node_modules/webpack": {
-			"version": "5.101.3",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.101.3.tgz",
-			"integrity": "sha512-7b0dTKR3Ed//AD/6kkx/o7duS8H3f1a4w3BYpIriX4BzIhjkn4teo05cptsxvLesHFKK5KObnadmCHBwGc+51A==",
+			"version": "5.107.2",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.107.2.tgz",
+			"integrity": "sha512-v7RhXaJbpMlV0D7hC7lb2EbnxkoeUqf9qhKr6lozx3Q48pmFrqqNRmZFUEGmi7pSwm6fCQ2H1IjvCkHqdpVdjQ==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@types/eslint-scope": "^3.7.7",
 				"@types/estree": "^1.0.8",
 				"@types/json-schema": "^7.0.15",
 				"@webassemblyjs/ast": "^1.14.1",
 				"@webassemblyjs/wasm-edit": "^1.14.1",
 				"@webassemblyjs/wasm-parser": "^1.14.1",
-				"acorn": "^8.15.0",
+				"acorn": "^8.16.0",
 				"acorn-import-phases": "^1.0.3",
-				"browserslist": "^4.24.0",
+				"browserslist": "^4.28.1",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.17.3",
-				"es-module-lexer": "^1.2.1",
+				"enhanced-resolve": "^5.22.0",
+				"es-module-lexer": "^2.1.0",
 				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",
 				"glob-to-regexp": "^0.4.1",
 				"graceful-fs": "^4.2.11",
-				"json-parse-even-better-errors": "^2.3.1",
-				"loader-runner": "^4.2.0",
-				"mime-types": "^2.1.27",
+				"loader-runner": "^4.3.2",
+				"mime-db": "^1.54.0",
 				"neo-async": "^2.6.2",
-				"schema-utils": "^4.3.2",
-				"tapable": "^2.1.1",
-				"terser-webpack-plugin": "^5.3.11",
-				"watchpack": "^2.4.1",
-				"webpack-sources": "^3.3.3"
+				"schema-utils": "^4.3.3",
+				"tapable": "^2.3.0",
+				"terser-webpack-plugin": "^5.5.0",
+				"watchpack": "^2.5.1",
+				"webpack-sources": "^3.5.0"
 			},
 			"bin": {
 				"webpack": "bin/webpack.js"
@@ -16226,16 +16661,16 @@
 			}
 		},
 		"node_modules/webpack-dev-server": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.2.tgz",
-			"integrity": "sha512-QcQ72gh8a+7JO63TAx/6XZf/CWhgMzu5m0QirvPfGvptOusAxG12w2+aua1Jkjr7hzaWDnJ2n6JFeexMHI+Zjg==",
+			"version": "5.2.5",
+			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.5.tgz",
+			"integrity": "sha512-4wZtCquSuv9CKX8oybo+mqxtxZqWz47uM1Ch94lxowBztOhWCbhqvRbfC/mODOwxgV2brY+JGZpHq58/SuVFYg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"@types/bonjour": "^3.5.13",
 				"@types/connect-history-api-fallback": "^1.5.4",
-				"@types/express": "^4.17.21",
+				"@types/express": "^4.17.25",
 				"@types/express-serve-static-core": "^4.17.21",
 				"@types/serve-index": "^1.9.4",
 				"@types/serve-static": "^1.15.5",
@@ -16245,9 +16680,9 @@
 				"bonjour-service": "^1.2.1",
 				"chokidar": "^3.6.0",
 				"colorette": "^2.0.10",
-				"compression": "^1.7.4",
+				"compression": "^1.8.1",
 				"connect-history-api-fallback": "^2.0.0",
-				"express": "^4.21.2",
+				"express": "^4.22.1",
 				"graceful-fs": "^4.2.6",
 				"http-proxy-middleware": "^2.0.9",
 				"ipaddr.js": "^2.1.0",
@@ -16255,7 +16690,7 @@
 				"open": "^10.0.3",
 				"p-retry": "^6.2.0",
 				"schema-utils": "^4.2.0",
-				"selfsigned": "^2.4.1",
+				"selfsigned": "^5.5.0",
 				"serve-index": "^1.9.1",
 				"sockjs": "^0.3.24",
 				"spdy": "^4.0.2",
@@ -16355,13 +16790,23 @@
 			}
 		},
 		"node_modules/webpack-sources": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
-			"integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.0.tgz",
+			"integrity": "sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
 				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/webpack/node_modules/mime-db": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.6"
 			}
 		},
 		"node_modules/websocket-driver": {
@@ -16544,9 +16989,9 @@
 			}
 		},
 		"node_modules/ws": {
-			"version": "8.18.3",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-			"integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+			"version": "8.21.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+			"integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -16592,6 +17037,21 @@
 			"peer": true,
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/xml-naming": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+			"integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.0.0"
 			}
 		},
 		"node_modules/xtend": {


### PR DESCRIPTION
# Audit report

This audit fix resolves 1 of the total 55 vulnerabilities found in your project.

## Updated dependencies
* [@nextcloud/eslint-config](#user-content-\\@nextcloud\\/eslint-config)
## Fixed vulnerabilities

### `@nextcloud/eslint-config` <a href="#user-content-\@nextcloud\/eslint-config" id="\@nextcloud\/eslint-config">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/eslint-plugin](#user-content-\@nextcloud\/eslint-plugin)
* Affected versions: 8.4.0 - 8.4.2
* Package usage:
  * `node_modules/@nextcloud/eslint-config`